### PR TITLE
Change "Pantsu"/"Pantsu.cat" allusions to site's name, to siteName variable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
         max_upload_size: 128,
         pkgVersion: '<%= pkg.version %>',
         production: false,
+        siteName: 'Pantsu',
         siteUrl: 'https://pantsu.cat/',
         src: [
           'templates/index.swig',

--- a/templates/faq.swig
+++ b/templates/faq.swig
@@ -6,17 +6,17 @@
 	<div class="jumbotron">
 		<h1><abbr title="Frequently asked questions">FAQ</abbr></h1>
 	</div>
-	<h2>What is Pantsu.cat?</h2>
-	<p><span role="definition"><dfn>Pantsu.cat</dfn> is a simple to use free file hosting service.</span> It lets you share your photos, documents, music, videos and more with others online.</p>
+	<h2>What is {{siteName}}?</h2>
+	<p><span role="definition"><dfn>{{siteName}}</dfn> is a simple to use free file hosting service.</span> It lets you share your photos, documents, music, videos and more with others online.</p>
 	<h2>What works are allowed?</h2>
-	<p>Pantsu.cat welcomes uploading all works, as long as the work is legal in Australia and you have the legal right to publish the work on our service.</p>
+	<p>{{siteName}} welcomes uploading all works, as long as the work is legal in Australia and you have the legal right to publish the work on our service.</p>
 	<p>As an exception to this policy to prevent abuse, we do not allow malware on our service. Any malware that could be used to infect other computers may be removed from our service at our discretion.</p>
 	<h2>Do you keep logs of uploaded works?</h2>
 	<p>We don't collect or log any data of our users in respect for privacy. We only have files uploaded by our users.</p>
 	<h2>Can you remove my copyrighted work?</h2>
 	<p>Please submit your copyright takedown notice to <a href="mailto:abuse@pantsu.cat">abuse@pantsu.cat</a>. We will handle your notice within 24 hours and disable access to the infringing work after receiving a notice compliant with the Copyright Act 1968 (Australia).</p>
 	<h2>Can you remove works that are defaming me or otherwise infringing my non-copyright rights?</h2>
-	<p>Pantsu.cat respects takedowns for other works when accompanied with a certified Australian court order. If you are unable to obtain the order, a preliminary injuction or court order is typically also sufficient. Please forward the notice to <a href="mailto:abuse@pantsu.cat">abuse@pantsu.cat</a>.</p>
+	<p>{{siteName}} respects takedowns for other works when accompanied with a certified Australian court order. If you are unable to obtain the order, a preliminary injuction or court order is typically also sufficient. Please forward the notice to <a href="mailto:abuse@pantsu.cat">abuse@pantsu.cat</a>.</p>
 	<h2>Can you remove illegal works?</h2>
 	<p>Please contact the appropriate law enforcement agency if you notice illegal works hosted on Pantsu.cat. We have not been trained or qualified to investigate and fight crimes and enforce the law, so it's not appropriate to send accusations of illegal activity to us. <strong>You must contact the appropriate law enforcement office.</strong> They may then contact us if appropriate.</p>
 	<p>If you are an Australian law enforcement official and you need our assistance, please contact <a href="mailto:abuse@pantsu.cat">abuse@pantsu.cat</a>. If you are a law enforcement official from another country, we may voluntarily cooperate if the crime you are investigating would also be illegal in Australia.</p>

--- a/templates/index.swig
+++ b/templates/index.swig
@@ -2,7 +2,7 @@
 
 {% block body %}
 <div class="jumbotron">
-	<h1>Pantsu~</h1>
+	<h1>{{siteName}}~</h1>
 	<p class="lead">Max upload size is {{max_upload_size}}&nbsp;MiB, read the <a href="faq.html"><abbr title="Frequently asked questions">FAQ</abbr></a></p>
 	{% include "upload_form.swig" %}
 </div>

--- a/templates/layout.swig
+++ b/templates/layout.swig
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="generator" content="Pomf {{pkgVersion}}">
-		<title>Pantsu.cat &middot; {% block title %}Kawaii File Hosting{% endblock %}</title>
+		<title>{{siteName}} &middot; {% block title %}Kawaii File Hosting{% endblock %}</title>
 		<link rel="icon" href="favicon.ico">
 		<link rel="stylesheet" href="pomf.min.css">
 		<script src="pomf.min.js"></script>

--- a/templates/nav.swig
+++ b/templates/nav.swig
@@ -1,9 +1,9 @@
 <nav>
 	<ul>
-		<li><a href="/">Pantsu</a></li>
+		<li><a href="/">{{siteName}}</a></li>
 		<li><a href="//p.pantsu.cat/">Paste</a></li>
 		<li><a href="tools.html">Tools</a></li>
-		<li><a href="//git.pantsu.cat/pantsu/pomf">Git</a></li>
+		<li><a href="https://github.com/pomf/pomf">Git</a></li>
 		<li><a href="//transparency.pantsu.cat">Transparency</a></li>
 	</ul>
 </nav>


### PR DESCRIPTION
Changes all references to the name of the site, to the siteName variable found in Gruntfile.js.

max_upload_size and siteUrl are already used similarly