### PR TITLE
Change default DB from MySQL placeholder to valid SQLite

### DIFF
--- a/php/includes/settings.inc.php
+++ b/php/includes/settings.inc.php
@@ -37,16 +37,16 @@
  * PDO_MYSQL DSN.
  * @param string POMF_DB_CONN DSN:host|unix_socket=hostname|path;dbname=database
  */
-define('POMF_DB_CONN', 'mysql:unix_socket=/tmp/mysql.sock;dbname=pomf');
+define('POMF_DB_CONN', 'sqlite3:/var/db/pomf/pomf.sq3');
 
 /**
  * PDO database login credentials
  */
 
-/** @param string POMF_DB_NAME Database username */
-define('POMF_DB_USER', 'pomf');
-/** @param string POMF_DB_PASS Database password */
-define('POMF_DB_PASS', '***');
+/** @param string|null POMF_DB_NAME Database username */
+define('POMF_DB_USER', null);
+/** @param string|null POMF_DB_PASS Database password */
+define('POMF_DB_PASS', null);
 
 /**
  * File system location where to store uploaded files


### PR DESCRIPTION
See: #11 for discussion; #17 adds schema and instructions without making SQLite the default

- has zero impact on already set up sites
- at the moment all MySQL settings in `settings.inc.php` are placeholders
- MySQL requires substantially more setup than SQLite
- SQLite simplifies pomf set up
- instructions on how to set up SQLite (very simple) are covered in #17 
- no instructions on setting up MySQL provided