### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: mkdirs swig htmlmin min-css min-js copy
+all: installdirs swig htmlmin min-css min-js install
 
 swig:
 	@node node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > dist/faq.html 
@@ -11,19 +11,19 @@ htmlmin:
 	@node node_modules/htmlmin/bin/htmlmin dist/tools.html -o dist/tools.html 
 	
 
-mkdirs:
+installdirs:
 	@mkdir -p ./dist/img
 
 min-css:
 	@node ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > ./dist/pomf.min.css
 
 min-js:
-	@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" >> ./dist/pomf.min.js 
+	@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > ./dist/pomf.min.js 
 	@echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> ./dist/pomf.min.js
 	@node ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> ./dist/pomf.min.js 
 	@echo "// @license-end" >> ./dist/pomf.min.js
 
-copy:
+install:
 	@cp -r ./php/* ./dist/
 	@cp  ./static/img/*.png ./dist/img
 	@cp  ./static/img/favicon.ico ./dist/favicon.ico

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: clean installdirs swig htmlmin min-css min-js install
+all: swig htmlmin min-css min-js
 
 swig:
 	@node node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > dist/faq.html 
@@ -23,7 +23,7 @@ min-js:
 	@node ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> ./dist/pomf.min.js 
 	@echo "// @license-end" >> ./dist/pomf.min.js
 
-install:
+install: installdirs
 	@cp -rf ./php/* ./dist/
 	@cp -f ./static/img/*.png ./dist/img
 	@cp  -f ./static/img/favicon.ico ./dist/favicon.ico

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-DESTDIR=./dist
+DESTDIR="./dist"
+TMPDIR := $(shell mktemp -d)
+TAR="/bin/tar"
 
 all: swig htmlmin min-css min-js
 
@@ -30,6 +32,14 @@ install: installdirs
 	@cp -vr ./php/* $(DESTDIR)/
 	@cp -v ./static/img/*.png $(DESTDIR)/img/
 	@cp -vT ./static/img/favicon.ico $(DESTDIR)/favicon.ico
+
+dist:
+	DESTDIR=$(TMPDIR)
+	export DESTDIR
+	install
+	@$(TAR) cJf pomf.tar.xz DESTDIR/
+	@rm -rf $(TMPDIR)
+	
 
 clean:
 	

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: installdirs swig htmlmin min-css min-js install
+all: clean installdirs swig htmlmin min-css min-js install
 
 swig:
 	@node node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > dist/faq.html 
@@ -24,9 +24,9 @@ min-js:
 	@echo "// @license-end" >> ./dist/pomf.min.js
 
 install:
-	@cp -r ./php/* ./dist/
-	@cp  ./static/img/*.png ./dist/img
-	@cp  ./static/img/favicon.ico ./dist/favicon.ico
+	@cp -rf ./php/* ./dist/
+	@cp -f ./static/img/*.png ./dist/img
+	@cp  -f ./static/img/favicon.ico ./dist/favicon.ico
 
 clean:
 	@rm -rf ./dist/

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,5 @@ install:
 	@cp  ./static/img/*.png ./dist/img
 	@cp  ./static/img/favicon.ico ./dist/favicon.ico
 
-
+clean:
+	@rm -rf ./dist/

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,37 @@
+DESTDIR=./dist
+
 all: swig htmlmin min-css min-js
 
 swig:
-	@node node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > dist/faq.html 
-	@node node_modules/swig/bin/swig.js render -j dist.json templates/index.swig > dist/index.html 
-	@node node_modules/swig/bin/swig.js render -j dist.json templates/tools.swig > dist/tools.html 
+	@node node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > $(DESTDIR)/faq.html 
+	@node node_modules/swig/bin/swig.js render -j dist.json templates/index.swig > $(DESTDIR)/index.html 
+	@node node_modules/swig/bin/swig.js render -j dist.json templates/tools.swig > $(DESTDIR)/tools.html 
 
 htmlmin:
-	@node node_modules/htmlmin/bin/htmlmin dist/index.html -o dist/index.html 
-	@node node_modules/htmlmin/bin/htmlmin dist/faq.html -o dist/faq.html 
-	@node node_modules/htmlmin/bin/htmlmin dist/tools.html -o dist/tools.html 
+	@node node_modules/htmlmin/bin/htmlmin dist/index.html -o $(DESTDIR)/index.html 
+	@node node_modules/htmlmin/bin/htmlmin dist/faq.html -o $(DESTDIR)/faq.html 
+	@node node_modules/htmlmin/bin/htmlmin dist/tools.html -o $(DESTDIR)/tools.html 
 	
 
 installdirs:
-	@mkdir -p ./dist/img
+	@mkdir -p $(DESTDIR)/
+	@mkdir -p $(DESTDIR)/img	
 
 min-css:
-	@node ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > ./dist/pomf.min.css
+	@node ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > $(DESTDIR)/pomf.min.css
 
 min-js:
-	@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > ./dist/pomf.min.js 
-	@echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> ./dist/pomf.min.js
-	@node ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> ./dist/pomf.min.js 
+	@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > $(DESTDIR)/pomf.min.js 
+	@echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> $(DESTDIR)/pomf.min.js
+	@node ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> $(DESTDIR)/pomf.min.js 
 	@echo "// @license-end" >> ./dist/pomf.min.js
 
 install: installdirs
-	@cp -rf ./php/* ./dist/
-	@cp -f ./static/img/*.png ./dist/img
-	@cp  -f ./static/img/favicon.ico ./dist/favicon.ico
+	@cp -vr ./php/* $(DESTDIR)/
+	@cp -v ./static/img/*.png $(DESTDIR)/img/
+	@cp -vT ./static/img/favicon.ico $(DESTDIR)/favicon.ico
 
 clean:
-	@rm -rf ./dist/
+	
+uninstall:
+	@rm -rf $(DESTDIR)/


### PR DESCRIPTION
- Previously min-js would continually append to the file with 
`@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" >> ./dist/pomf.min.js` (note the **>>**).  
Fixed so that it overwrites the file whenever it is run now.

- added **uninstall** support as per Makefile conventions
- added DESTDIR support -- allows specifying installation destination directory in standard Makefile way
- **mkdirs** was renamed to **installdirs** as per makefile conventions
- **copy** was renamed to **install** for the same reasons