### PR TITLE
Significant Makefile improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
 - nvm ls-remote
 - nvm install stable
 - nvm use stable
-- npm install
 script:
 - make 
 

--- a/Makefile
+++ b/Makefile
@@ -10,53 +10,53 @@ TMPDIR := $(shell mktemp -d)
 all: builddirs npm_dependencies swig htmlmin min-css min-js copy-img copy-php
 
 swig:
-	@$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > $(CURDIR)/build/faq.html 
-	@$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/index.swig > $(CURDIR)/build/index.html 
-	@$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/tools.swig > $(CURDIR)/build/tools.html 
+	$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > $(CURDIR)/build/faq.html 
+	$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/index.swig > $(CURDIR)/build/index.html 
+	$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/tools.swig > $(CURDIR)/build/tools.html 
 
 htmlmin:
-	@$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/index.html -o $(CURDIR)/build/index.html 
-	@$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/faq.html -o $(CURDIR)/build/faq.html 
-	@$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/tools.html -o $(CURDIR)/build/tools.html 
+	$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/index.html -o $(CURDIR)/build/index.html 
+	$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/faq.html -o $(CURDIR)/build/faq.html 
+	$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/tools.html -o $(CURDIR)/build/tools.html 
 
 installdirs:
-	@mkdir -p $(DESTDIR)/ $(DESTDIR)/img $(DESTDIR)/classes $(DESTDIR)/includes
+	mkdir -p $(DESTDIR)/ $(DESTDIR)/img $(DESTDIR)/classes $(DESTDIR)/includes
 	
 min-css:
-	@$(NODE) ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > $(CURDIR)/build/pomf.min.css
+	$(NODE) ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > $(CURDIR)/build/pomf.min.css
 
 min-js:
-	@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > $(CURDIR)/build/pomf.min.js 
-	@echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> $(CURDIR)/build/pomf.min.js
-	@$(NODE) ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> $(CURDIR)/build/pomf.min.js 
-	@echo "// @license-end" >> $(CURDIR)/build/pomf.min.js
+	echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > $(CURDIR)/build/pomf.min.js 
+	echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> $(CURDIR)/build/pomf.min.js
+	$(NODE) ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> $(CURDIR)/build/pomf.min.js 
+	echo "// @license-end" >> $(CURDIR)/build/pomf.min.js
 
 copy-img:
-	@cp -v ./static/img/*.png $(CURDIR)/build/img/
-	@cp -vT ./static/img/favicon.ico $(CURDIR)/build/favicon.ico
+	cp -v ./static/img/*.png $(CURDIR)/build/img/
+	cp -vT ./static/img/favicon.ico $(CURDIR)/build/favicon.ico
 
 copy-php:
-	@cp -rv ./php/* $(CURDIR)/build/
+	cp -rv ./php/* $(CURDIR)/build/
 
 install: installdirs
-	@cp -rv $(CURDIR)/build/* $(DESTDIR)/
+	cp -rv $(CURDIR)/build/* $(DESTDIR)/
 
 dist:
 	DESTDIR=$(TMPDIR)/pomf-$(PKGVERSION)
 	export DESTDIR
 	install
-	@$(TAR) cJf pomf-$(PKG_VERSION).tar.xz $(DESTDIR)
-	@rm -rf $(TMPDIR)
+	$(TAR) cJf pomf-$(PKG_VERSION).tar.xz $(DESTDIR)
+	rm -rf $(TMPDIR)
 	
 clean:
-	@rm -rvf $(CURDIR)/node_modules 
-	@rm -rvf $(CURDIR)/build
+	rm -rvf $(CURDIR)/node_modules 
+	rm -rvf $(CURDIR)/build
 	
 uninstall:
-	@rm -rvf $(DESTDIR)/
+	rm -rvf $(DESTDIR)/
 	
 npm_dependencies:
-	@$(NPM) install
+	$(NPM) install
 
 builddirs:
-	@mkdir -p $(CURDIR)/build $(CURDIR)/build/img $(CURDIR)/build/classes $(CURDIR)/build/includes
+	mkdir -p $(CURDIR)/build $(CURDIR)/build/img $(CURDIR)/build/classes $(CURDIR)/build/includes

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,64 @@
-all: mkdirs swig htmlmin min-css min-js copy
+INSTALL="/bin/install"
+TAR="/bin/tar"
+GREP="/bin/grep"
+NODE="/usr/bin/node"
+NPM="/usr/bin/npm"
+DESTDIR="./dist"
+PKG_VERSION := $( $(GREP) -Po '(?<="version": ")[^"]*' )
+TMPDIR := $(shell mktemp -d)
+prefix="/usr/local"
+localstatedir=$(prefix)/var
+
+all: builddirs npm_dependencies swig htmlmin min-css min-js copy-img copy-php
 
 swig:
-	@node node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > dist/faq.html 
-	@node node_modules/swig/bin/swig.js render -j dist.json templates/index.swig > dist/index.html 
-	@node node_modules/swig/bin/swig.js render -j dist.json templates/tools.swig > dist/tools.html 
+	@$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/faq.swig > $(CURDIR)/build/faq.html 
+	@$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/index.swig > $(CURDIR)/build/index.html 
+	@$(NODE) node_modules/swig/bin/swig.js render -j dist.json templates/tools.swig > $(CURDIR)/build/tools.html 
 
 htmlmin:
-	@node node_modules/htmlmin/bin/htmlmin dist/index.html -o dist/index.html 
-	@node node_modules/htmlmin/bin/htmlmin dist/faq.html -o dist/faq.html 
-	@node node_modules/htmlmin/bin/htmlmin dist/tools.html -o dist/tools.html 
+	@$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/index.html -o $(CURDIR)/build/index.html 
+	@$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/faq.html -o $(CURDIR)/build/faq.html 
+	@$(NODE) node_modules/htmlmin/bin/htmlmin $(CURDIR)/build/tools.html -o $(CURDIR)/build/tools.html 
+
+installdirs:
+	@mkdir -p $(DESTDIR)/ $(DESTDIR)/img $(DESTDIR)/classes $(DESTDIR)/includes
 	
-
-mkdirs:
-	@mkdir -p ./dist/img
-
 min-css:
-	@node ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > ./dist/pomf.min.css
+	@$(NODE) ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > $(CURDIR)/build/pomf.min.css
 
 min-js:
-	@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" >> ./dist/pomf.min.js 
-	@echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> ./dist/pomf.min.js
-	@node ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> ./dist/pomf.min.js 
-	@echo "// @license-end" >> ./dist/pomf.min.js
+	@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > $(CURDIR)/build/pomf.min.js 
+	@echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> $(CURDIR)/build/pomf.min.js
+	@$(NODE) ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> $(CURDIR)/build/pomf.min.js 
+	@echo "// @license-end" >> $(CURDIR)/build/pomf.min.js
 
-copy:
-	@cp -r ./php/* ./dist/
-	@cp  ./static/img/*.png ./dist/img
-	@cp  ./static/img/favicon.ico ./dist/favicon.ico
+copy-img:
+	@cp -v ./static/img/*.png $(CURDIR)/build/img/
+	@cp -vT ./static/img/favicon.ico $(CURDIR)/build/favicon.ico
 
+copy-php:
+	@cp -rv ./php/* $(CURDIR)/build/
 
+install: installdirs
+	@cp -rv $(CURDIR)/build/* $(DESTDIR)/
+
+dist:
+	DESTDIR=$(TMPDIR)/pomf-$(PKGVERSION)
+	export DESTDIR
+	install
+	@$(TAR) cJf pomf-$(PKG_VERSION).tar.xz $(DESTDIR)
+	@rm -rf $(TMPDIR)
+	
+clean:
+	@rm -rvf $(CURDIR)/node_modules 
+	@rm -rvf $(CURDIR)/build
+	
+uninstall:
+	@rm -rvf $(DESTDIR)/
+	
+npm_dependencies:
+	@$(NPM) install
+
+builddirs:
+	@mkdir -p $(CURDIR)/build $(CURDIR)/build/img $(CURDIR)/build/classes $(CURDIR)/build/includes

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
-INSTALL="/bin/install"
-TAR="/bin/tar"
-GREP="/bin/grep"
-NODE="/usr/bin/node"
-NPM="/usr/bin/npm"
+INSTALL="install"
+TAR="tar"
+GREP="grep"
+NODE="node"
+NPM="npm"
 DESTDIR="./dist"
 PKG_VERSION := $( $(GREP) -Po '(?<="version": ")[^"]*' )
 TMPDIR := $(shell mktemp -d)
-prefix="/usr/local"
-localstatedir=$(prefix)/var
 
 all: builddirs npm_dependencies swig htmlmin min-css min-js copy-img copy-php
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,17 @@ Node, or NPM. So we'll just assume you already have them all running well.
 
 Assuming you already have Node and NPM working, compilation is easy. Use the
 following shell code:
-
-    git clone https://github.com/pomf/pomf
-    cd pomf/
-    npm install
-    make
-
-After this, the pomf site is now compressed and set up inside `dist/`.
+```bash
+git clone https://github.com/pomf/pomf
+cd pomf/
+make
+make install
+```
+OR
+```bash
+make install DESTDIR=/desired/path/for/site
+```
+After this, the pomf site is now compressed and set up inside `dist/`, or, if specified, `DESTDIR`.
 
 ## Configuring
 


### PR DESCRIPTION
(squashed commits on previous one so can't reopen)

- Previously min-js would continually append to the file with 
`@echo "// @source https://github.com/pomf/pomf/tree/master/static/js" >> ./dist/pomf.min.js` (note the **>>**).  
Fixed so that it overwrites the file whenever it is run now.

- generally made a number of changes so Makefile better follows conventions
- added **uninstall** support as per Makefile conventions
- added DESTDIR support -- allows specifying installation destination directory in standard Makefile way
- added **dist** support -- allows archive containing the "compiled" site to be produced via `make dist`
- replaced program names with the appropriate variables as per makefile conventions
- **mkdirs** was renamed to **installdirs** as per makefile conventions
- **copy** was renamed to **install** for the same reasons
- added clean and uninstall targets