### PR TITLE
Improved MySQL to SQLite migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Node, or NPM. So we'll just assume you already have them all running well.
 Assuming you already have Node and NPM working, compilation is easy. Use the
 following shell code:
 ```bash
-git clone --recursive https://github.com/pomf/pomf
+git clone https://github.com/pomf/pomf
 cd pomf/
 make
 make install
@@ -103,11 +103,17 @@ Remember to enable `deflate_module` and `filter_module` modules in your Apache
 configuration file.
 
 ### Migrating from MySQL to SQLite
+ ,
+Compared to SQLite, MySQL is relatively complicated to administer, brings in many unneeded dependencies, and consumes more resources.  Additonally, as a network service, poorly configured installations have the potential
+to pose a security risk.
 
-For older versions of Pomf you may want to migrate to SQLite. Fortunately, it is incredibly simple to migrate your database.  This may be done on a live server, and should require zero downtime.
+For these reasons, you may wish to use SQLite rather than MySQL.
 
-_If doing this on a live server, you way wish to work in a subdirectory (or vhost, or equivelant), so that any complications or mistakes do not affect your main site.  
-If you choose not to do so, know that mistakes in the changes outlined below, will only temporarily impact **uploading**, causing **Server error** to be displayed.  None of these steps are destructive, and are easily reverted._
+Fortunately, it is incredibly simple to migrate your database.  This may be done on a live server, if you desire, and requires zero downtime.
+
+The process described below involves running these commands on a live server.  Nothing done here affects your main site, until running the very last command, which is done after verifying there are no issues.  
+
+No changes described here are destructive, and are easily reverted.  They only have the potential to cause uploading to fail gracefully, and will not affect downloading.
 
 Run the following commands as root, to dump your database, and make a SQLite database with the contents.  
 ```bash
@@ -118,14 +124,15 @@ rm /tmp/m2s
 chown -R nginx:nginx /var/db/pomf #replace user as appropriate
 chmod 0750 /var/db/pomf && chmod 0640 /var/db/pomf/sq3
 ```
-Edit the file `php/includes/settings.inc.php`, in the subdirectory you just made, making the changes outlined below.
+Edit the file `php/includes/settings.inc.php`, in your **source directory**, making the changes outlined below.  Note, changing the second two lines is optional, as they are simply ignored when using SQLite.
 ```php
 define('POMF_DB_CONN', '[stuff]'); ---> define('POMF_DB_CONN', 'sqlite:/var/db/pomf/pomf.sq3');`
 define('POMF_DB_USER', '[stuff]'); ---> define('POMF_DB_USER', null);
 define('POMF_DB_PASS', '[stuff]'); ---> define('POMF_DB_PASS', null);
 ```
+Then, run `make DESTDIR=/path/to/main_site/testing_dir` (note the *testing_dir* component) to rebuild the website, and copy it into place, in a new testing subdirectory.
 
-Then, run `make` to rebuild the website pages, and copy the new `settings.inc.php` file into place. 
+Now, navigate to this subdirectory in your web browser, e.g. https://try.pantsu.cat/testing_dir, and verify that uploading works fine.  If so, excellent!  You may rerun `make DESTDIR=/path/to/main_site` to update your main site.
 
 All done! You may disable or uninstall MySQL if you wish.
 


### PR DESCRIPTION
The initial paragraph explaining why you may prefer to use SQLite was made more brief, and rephrased to sound more neutral (note that it already was neutral).

*The changes described below I think are quite significant to conveying the intended meaning of some parts of the instructions.*

The clarifying section prior to the actual migration instructions was rewritten to better convey that the changes are non-destructive, and that they do not affect the user's main site until the final command (whose purpose is made clear), after verifying there are no issues.

The instructions themselves have been modified to clarify where some commands are run from, their purpose, and also made more brief (the section itself is very slightly longer, but something happened to or I forgot to commit an important paragraph that was initially there).

@ewhal 