### PR TITLE
Added submodule support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,21 +32,21 @@ ifneq (,$(findstring moe,$(MODULES)))
 endif
 	
 min-css:
-	$(NODE) ./node_modules/.bin/cleancss --s0 ./static/css/pomf.css > $(CURDIR)/build/pomf.min.css
+	$(NODE) $(CURDIR)/node_modules/.bin/cleancss --s0 $(CURDIR)/static/css/pomf.css > $(CURDIR)/build/pomf.min.css
 
 min-js:
 	echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > $(CURDIR)/build/pomf.min.js 
 	echo "// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat" >> $(CURDIR)/build/pomf.min.js
-	$(NODE) ./node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> $(CURDIR)/build/pomf.min.js 
+	$(NODE) $(CURDIR)/node_modules/.bin/uglifyjs  --screw-ie8 ./static/js/app.js >> $(CURDIR)/build/pomf.min.js 
 	echo "// @license-end" >> $(CURDIR)/build/pomf.min.js
 
 copy-img:
-	cp -v ./static/img/*.png $(CURDIR)/build/img/
-	cp -vT ./static/img/favicon.ico $(CURDIR)/build/favicon.ico
+	cp -v $(CURDIR)/static/img/*.png $(CURDIR)/build/img/
+	cp -vT $(CURDIR)/static/img/favicon.ico $(CURDIR)/build/favicon.ico
 
 copy-php:
 ifneq ($(wildcard $(CURDIR)/php/.),)
-	cp -rv ./php/* $(CURDIR)/build/
+	cp -rv $(CURDIR)/php/* $(CURDIR)/build/
 else
 	$(error The php submodule was not found)
 endif

--- a/README.md
+++ b/README.md
@@ -39,12 +39,27 @@ Node, or NPM. So we'll just assume you already have them all running well.
 
 ### Compiling
 
-Assuming you already have Node and NPM working, compilation is easy. Use the
-following shell code:
+First you must get a copy of the pomf code.  To do so, clone this git repo.
+If you have no desire for any submodules, which includes the PHP backend, simply run
+```bash
+git clone https://github.com/pomf/pomf
+```
+else, run
 ```bash
 git clone --recursive https://github.com/pomf/pomf
+```
+to automatically fetch all of the submodules as well
+
+Assuming you already have Node and NPM working, compilation is easy. If you would like any additional submodules, or to exclude the default PHP submodule, use the `MODULES="..."` variable.
+
+Run the following commands to do so.
+```bash
 cd pomf/
 make
+# alternatively
+make MODULES="" # compile no submodules; exclude the default php backend module
+make MODULES="php moe" # compile the php and moe submodules
+#
 make install
 ```
 OR


### PR DESCRIPTION
Implements submodule support; see #39.  Also incidentally implements moe support.

The default is to include the php module and no other modules.

Modules are specified like
```bash
make MODULES="php moe"
```
This is explained in the readme.

@ewhal 