### PR TITLE
Corrected destination path for copy-moe target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 
 copy-moe:
 ifneq ($(wildcard $(CURDIR)/moe/.),)
-	cp -rv $(CURDIR)/moe $(CURDIR)/build/moe
+	cp -rv $(CURDIR)/moe $(CURDIR)/build/
 else
 	$(error The moe submodule was not found)
 endif


### PR DESCRIPTION
Previously the line copied the moe dir to DESTDIR/moe/, resulting in the path of the dir itself being DESTDIR/moe/moe.  Fixed this

@ewhal merge pls