### PR TITLE
Fixed copy URL button issue (#45)

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -97,6 +97,7 @@ document.addEventListener('DOMContentLoaded', function () {
           link.appendChild(element); 
           var range = document.createRange();
           range.selectNode(element);
+          window.getSelection().removeAllRanges();
           window.getSelection().addRange(range);
           document.execCommand("copy");
           link.removeChild(element);


### PR DESCRIPTION
I believe this fixes #45.

Previously, the second link you clicked the copy button for would be added onto the initial selection, as it was never removed.  This is the cause of the discontinuous selection error, and why sometimes two links would be copied.

Now, immediately before the new range is selected, `window.getSelection.removeAllRanges();` is run to clear the selection.