### PR TITLE
In tools page update ShareX links

### DIFF
--- a/templates/tools.swig
+++ b/templates/tools.swig
@@ -36,9 +36,11 @@
 	<h2>ShareX</h2>
 	<dl>
 		<dt>Download</dt>
-		<dd><a href="https://github.com/ShareX/ShareX/">https://github.com/ShareX/ShareX/</a></dd>
-		<dt>Settings</dt>
-		<dd><a href="https://p.pantsu.cat/view/raw/8c36da7e">https://p.pantsu.cat/view/raw/8c36da7e</a></dd>
+		<dd><a href="https://getsharex.com">https://getsharex.com</a></dd>
+		<dt>Source</dt>
+		<dd><a href="https://github.com/ShareX/ShareX">https://github.com/ShareX/ShareX</a></dd>
+		<dt>Contact</dt>
+		<dd><a href="https://webchat.freenode.net/?channels=%23ShareX">#ShareX on irc.freenode.net</a></dd>
 	</dl>
 </section>
 <section>


### PR DESCRIPTION
Updated download link to point ShareX home page. Removed broken settings link which probably was pointing to custom uploader script and it is not required anymore. Also added IRC channel as contact.