### PR TITLE
MakeFile Changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifneq (,$(findstring moe,$(MODULES)))
 endif
 	
 min-css:
-	$(NODE) $(CURDIR)/node_modules/.bin/cleancss --s0 $(CURDIR)/static/css/pomf.css > $(CURDIR)/build/pomf.min.css
+	$(NODE) $(CURDIR)/node_modules/.bin/cleancss --O1 specialComments:0 $(CURDIR)/static/css/pomf.css > $(CURDIR)/build/pomf.min.css
 
 min-js:
 	echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > $(CURDIR)/build/pomf.min.js 


### PR DESCRIPTION
CleanCSS v4.0 moved the --s0 flag for the node call to a different optimization level., Changed Makefile to use proper syntax.

see https://github.com/jakubpawlowicz/clean-css#important-40-breaking-changes

