### PR TITLE
Fix cleancss binary dependancies and URL rebasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifneq (,$(findstring moe,$(MODULES)))
 endif
 	
 min-css:
-	$(NODE) $(CURDIR)/node_modules/.bin/cleancss --O1 specialComments:0 $(CURDIR)/static/css/pomf.css > $(CURDIR)/build/pomf.min.css
+	$(NODE) $(CURDIR)/node_modules/.bin/cleancss --skip-rebase --O1 specialComments:0 $(CURDIR)/static/css/pomf.css --output $(CURDIR)/build/pomf.min.css
 
 min-js:
 	echo "// @source https://github.com/pomf/pomf/tree/master/static/js" > $(CURDIR)/build/pomf.min.js 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "clean-css": "^4.2.1",
+    "clean-css-cli": "^4.3.0",
     "uglify-js": "^2.6.2",
     "swig": "^1.4.2"
   },


### PR DESCRIPTION
It seems the latest version of clean-css does not actually include the cleancss binary, this is remedied by including the clean-css-cli package as a dev dependency.

Further, changes to how URL rebasing is applied leads to issues with internal css linking, so this fixes that with the correct syntax '--skip-rebase'.

Finally as a small code cleanup measure, this uses the newly provided '--output' option with version '4.3.0' of the cleancss binary, eliminating the need to pipe from stout.